### PR TITLE
Fix backward-incompat issues in daemon

### DIFF
--- a/pkg/v1/daemon/options.go
+++ b/pkg/v1/daemon/options.go
@@ -22,6 +22,11 @@ import (
 	"github.com/docker/docker/client"
 )
 
+// ImageOption is an alias for Option.
+// Deprecated: Use Option instead.
+type ImageOption Option
+
+// Option is a functional option for daemon operations.
 type Option func(*options)
 
 type options struct {

--- a/pkg/v1/daemon/write_test.go
+++ b/pkg/v1/daemon/write_test.go
@@ -146,7 +146,7 @@ func TestWriteDefaultClient(t *testing.T) {
 	}
 
 	// Cover default client init and ctx use as well.
-	ctx := context.WithValue(context.Background(), "hello", "world")
+	ctx := context.TODO()
 	defaultClient = func() (Client, error) {
 		return &MockClient{
 			loadBody: ioutil.NopCloser(strings.NewReader("Loaded")),


### PR DESCRIPTION
We exposed ImageOption, so we need to keep that symbol alive.

Also fix some linter complaints.